### PR TITLE
Close #77: Auto load the recent calendar view mode value

### DIFF
--- a/src/utils/consts.js
+++ b/src/utils/consts.js
@@ -7,3 +7,4 @@ export const
 
 const LS_SCHEDULE_PREFIX = "schedule_";
 export const LS_KEY_SCHEDULE_FILTER_STELLAR_IDS = `${LS_SCHEDULE_PREFIX}filter_stellar_ids`;
+export const LS_KEY_CALENDAR_VIEW_MODE = `${LS_SCHEDULE_PREFIX}calendar_view_mode`;

--- a/src/views/SchedulesView.vue
+++ b/src/views/SchedulesView.vue
@@ -129,7 +129,7 @@
 import { Calendar } from 'v-calendar';
 import { DateTime } from 'luxon';
 import ScheduleItem from '@/components/ScheduleItem.vue';
-import { STELLARS_API_URL, SCHEDULES_API_URL, LOGIN_INFO_KEY, LS_KEY_SCHEDULE_FILTER_STELLAR_IDS } from '@/utils/consts';
+import { STELLARS_API_URL, SCHEDULES_API_URL, LOGIN_INFO_KEY, LS_KEY_SCHEDULE_FILTER_STELLAR_IDS, LS_KEY_CALENDAR_VIEW_MODE } from '@/utils/consts';
 import ScheduleDialog from '@/components/ScheduleDialog.vue';
 import { formatDateTime } from '@/utils/common';
 import { useDisplay } from 'vuetify';
@@ -144,9 +144,12 @@ export default {
       }
     },
     data() {
-      const month = new Date().getMonth();
-      const year = new Date().getFullYear();
       const { mdAndDown } = useDisplay();
+      const calendarViewItems = [
+        { title: "주간", value: "weekly" },
+        { title: "월간", value: "monthly" },
+      ];
+      const storedCalendarView = localStorage.getItem(LS_KEY_CALENDAR_VIEW_MODE);
       return {
         masks: {
           title: "YYYY년 MMM",
@@ -159,11 +162,8 @@ export default {
         schedules: [],
         dialog: false,
         alertList: [],
-        calendarView: "weekly",
-        calendarViewItems: [
-          { title: "주간", value: "weekly" },
-          { title: "월간", value: "monthly"},
-        ],
+        calendarView: calendarViewItems.some(item => item.value === storedCalendarView) ? storedCalendarView : "weekly",
+        calendarViewItems,
         mdAndDown,
       };
     },
@@ -309,7 +309,9 @@ export default {
       }
     },
     watch: {
-      calendarView() {
+      calendarView(newValue) {
+        // Save the most recently set calendar view mode to localStorage
+        localStorage.setItem(LS_KEY_CALENDAR_VIEW_MODE, newValue);
         this.loadSchedules();
       }
     }


### PR DESCRIPTION
This PR is to load automatically the value of calendar view mode which is most recently set by the user.

- Store the calendar view mode value into local storage.
- Load it when a user enter the page.