### PR TITLE
Close #86: Add new stellar handling in ScheduleView

### DIFF
--- a/src/utils/consts.js
+++ b/src/utils/consts.js
@@ -7,4 +7,5 @@ export const
 
 const LS_SCHEDULE_PREFIX = "schedule_";
 export const LS_KEY_SCHEDULE_FILTER_STELLAR_IDS = `${LS_SCHEDULE_PREFIX}filter_stellar_ids`;
+export const LS_KEY_SCHEDULE_FILTER_LAST_ADDED_STELLAR_ID = `${LS_SCHEDULE_PREFIX}filter_last_added_stellar_id`;
 export const LS_KEY_CALENDAR_VIEW_MODE = `${LS_SCHEDULE_PREFIX}calendar_view_mode`;

--- a/src/views/SchedulesView.vue
+++ b/src/views/SchedulesView.vue
@@ -319,7 +319,7 @@ export default {
           color,
         });
         // 3초 뒤 자동으로 alert 제거
-        setInterval(() => {
+        setTimeout(() => {
           this.alertList = this.alertList.filter(alert => alert.key !== key);
         }, 3000);
       },

--- a/src/views/SchedulesView.vue
+++ b/src/views/SchedulesView.vue
@@ -219,7 +219,8 @@ export default {
       getFilteredStellarIds(storedIdJson) {
         try {
           const parsedStellarIds = JSON.parse(storedIdJson);
-          return this.stellars.map(s => s.id).filter(id => parsedStellarIds.includes(id));
+          const parsedSet = new Set(parsedStellarIds);
+          return this.stellars.map(s => s.id).filter(id => parsedSet.has(id));
         }
         catch (e) {
           console.error("Error parsing stellarIds from localStorage:", e);

--- a/src/views/SchedulesView.vue
+++ b/src/views/SchedulesView.vue
@@ -235,9 +235,12 @@ export default {
         return isNaN(lastAddedId) ? 12 : lastAddedId;
       },
       addNewStellarsToFilter(lastAddedId, maxId) {
+        const validStellarIds = new Set(this.stellars.map(s => s.id));
         const newStellarIds = [];
         for (let i = lastAddedId + 1; i <= maxId; i++) {
-          newStellarIds.push(i);
+          if (validStellarIds.has(i)) {
+            newStellarIds.push(i);
+          }
         }
         this.stellarIds = [...new Set([...this.stellarIds, ...newStellarIds])];
       },


### PR DESCRIPTION
This pull request enhances the schedule filtering logic to automatically include newly added "stellars" in user filters and persist this information in local storage. The changes improve user experience by ensuring that filters remain up-to-date as new stellars are introduced, without requiring manual intervention.

**Improvements to schedule filter persistence and initialization:**

* Added a new constant `LS_KEY_SCHEDULE_FILTER_LAST_ADDED_STELLAR_ID` in `src/utils/consts.js` to track the last stellar ID included in the filter.
* Refactored the initialization logic in `src/views/SchedulesView.vue` to use a new method `fetchStellarsAndInitFilter`, which loads stellars, sorts them, and initializes the filter based on local storage.
* Implemented logic to detect and automatically add new stellars to the filter if their IDs are higher than the last saved ID, updating both the filter and the last added ID in local storage.
* Updated the `saveFilter` method to persist both the selected stellar IDs and the latest stellar ID to local storage, ensuring future filter updates can be handled automatically.

**General code improvements:**

* Replaced `setInterval` with `setTimeout` for alert removal to avoid unnecessary repeated execution.