### PR TITLE
Close #97: Collapsible schedule settings panel with FAB toggle

### DIFF
--- a/src/views/SchedulesView.vue
+++ b/src/views/SchedulesView.vue
@@ -79,13 +79,32 @@
       :stellars="stellars"
     ></ScheduleDialog>
   </v-dialog>
-  <div class="fab-div" v-if="loginInfo.isLoggedIn">
+  <div
+    class="schedules-view-fab"
+    :class="loginInfo.isLoggedIn ? 'schedules-view-fab--stacked-above' : 'schedules-view-fab--lower'"
+  >
+    <v-tooltip text="캘린더 설정" location="start">
+      <template v-slot:activator="{ props }">
+        <v-btn
+          v-bind="props"
+          :icon="showSettings ? 'mdi-close' : 'mdi-cog-outline'"
+          color="surface-variant"
+          size="large"
+          @click="toggleSettingsPanel"
+        />
+      </template>
+    </v-tooltip>
+  </div>
+  <div
+    class="schedules-view-fab schedules-view-fab--lower"
+    v-if="loginInfo.isLoggedIn"
+  >
     <v-btn
-        icon="mdi-plus"
-        color="primary"
-        size="large"
-        @click="openDialogCreation"
-      ></v-btn>
+      icon="mdi-plus"
+      color="primary"
+      size="large"
+      @click="openDialogCreation"
+    />
   </div>
 </template>
 
@@ -136,7 +155,7 @@ export default {
         calendarView: calendarViewOptions.some(item => item.value === storedCalendarView) ? storedCalendarView : "weekly",
         calendarViewOptions,
         mdAndDown,
-        showSettings: true,
+        showSettings: false,
       };
     },
     created() {
@@ -265,6 +284,9 @@ export default {
       openDialogCreation() {
         this.dialog = true;
       },
+      toggleSettingsPanel() {
+        this.showSettings = !this.showSettings;
+      },
       onSavedSchedule() {
         this.dialog = false;
         this.pushAlert("스케줄이 등록되었습니다.");
@@ -339,11 +361,18 @@ export default {
   min-height: 100px;
 }
 
-.fab-div {
+.schedules-view-fab {
   position: fixed;
-  bottom: 50px;
   right: 50px;
   z-index: 1;
+}
+
+.schedules-view-fab--stacked-above {
+  bottom: 130px;
+}
+
+.schedules-view-fab--lower {
+  bottom: 50px;
 }
 
 .today {
@@ -361,23 +390,6 @@ export default {
 .fade-enter-from,
 .fade-leave-to {
   opacity: 0;
-}
-
-.filter-label {
-  color: #000;
-}
-
-.filter-label.graduated {
-  color: #888;
-}
-
-.emoji-span {
-  margin: 0 1px;
-}
-
-.name-span {
-  vertical-align: middle;
-  margin-left: 3px;
 }
 
 </style>


### PR DESCRIPTION
This pull request updates the floating action button (FAB) controls in the `SchedulesView.vue` to improve the calendar settings accessibility and refines the FAB layout for better usability. The main changes include introducing a dedicated FAB for toggling the calendar settings panel, updating the FAB positioning logic and styles, and adding a tooltip for the settings button.

**UI/UX Improvements:**

* Added a new FAB for toggling the calendar settings panel, including a tooltip and icon that changes between "settings" and "close" (`mdi-cog-outline`/`mdi-close`).
* Changed the FAB layout: the settings FAB is always visible, and the "add schedule" FAB is conditionally stacked above or below based on login status and CSS classes. [[1]](diffhunk://#diff-36c032cff02681b35386ea8ec8929b37f2b9a3ec1f967e49a076564ba08943fdL82-R107) [[2]](diffhunk://#diff-36c032cff02681b35386ea8ec8929b37f2b9a3ec1f967e49a076564ba08943fdL342-R377)
* Updated the default value of `showSettings` to `false` so the settings panel is hidden by default.
* Added a new `toggleSettingsPanel` method to handle showing/hiding the settings panel when the settings FAB is clicked.

**Styling and Cleanup:**

* Refactored and renamed FAB-related CSS classes for clarity (`fab-div` → `schedules-view-fab`, with new modifier classes for positioning), and removed unused style blocks. [[1]](diffhunk://#diff-36c032cff02681b35386ea8ec8929b37f2b9a3ec1f967e49a076564ba08943fdL342-R377) [[2]](diffhunk://#diff-36c032cff02681b35386ea8ec8929b37f2b9a3ec1f967e49a076564ba08943fdL366-L382)