### PR TITLE
Close #110: Focus the schedule settings panel when opens it in mobile device

### DIFF
--- a/src/views/SchedulesView.vue
+++ b/src/views/SchedulesView.vue
@@ -290,7 +290,9 @@ export default {
         this.showSettings = !this.showSettings;
         if (this.showSettings && !this.xlAndUp) {
           this.$nextTick(() => {
-            this.$refs.settingsCol.$el.scrollIntoView({ behavior: 'smooth' });
+            if (this.showSettings && this.$refs.settingsCol?.$el) {
+              this.$refs.settingsCol.$el.scrollIntoView({ behavior: 'smooth' });
+            }
           });
         }
       },

--- a/src/views/SchedulesView.vue
+++ b/src/views/SchedulesView.vue
@@ -135,7 +135,7 @@ export default {
       }
     },
     data() {
-      const { mdAndDown } = useDisplay();
+      const { mdAndDown, xlAndUp } = useDisplay();
       const calendarViewOptions = [
         { title: "주간", value: "weekly" },
         { title: "월간", value: "monthly" },
@@ -156,6 +156,7 @@ export default {
         calendarView: calendarViewOptions.some(item => item.value === storedCalendarView) ? storedCalendarView : "weekly",
         calendarViewOptions,
         mdAndDown,
+        xlAndUp,
         showSettings: false,
       };
     },
@@ -287,7 +288,7 @@ export default {
       },
       toggleSettingsPanel() {
         this.showSettings = !this.showSettings;
-        if (this.showSettings) {
+        if (this.showSettings && !this.xlAndUp) {
           this.$nextTick(() => {
             this.$refs.settingsCol.$el.scrollIntoView({ behavior: 'smooth' });
           });

--- a/src/views/SchedulesView.vue
+++ b/src/views/SchedulesView.vue
@@ -22,6 +22,7 @@
         v-if="showSettings"
         cols="12"
         xl="2"
+        ref="settingsCol"
       >
         <ScheduleSettingsPanel
           v-model:calendarView="calendarView"
@@ -286,6 +287,11 @@ export default {
       },
       toggleSettingsPanel() {
         this.showSettings = !this.showSettings;
+        if (this.showSettings) {
+          this.$nextTick(() => {
+            this.$refs.settingsCol.$el.scrollIntoView({ behavior: 'smooth' });
+          });
+        }
       },
       onSavedSchedule() {
         this.dialog = false;


### PR DESCRIPTION
This pull request enhances the user experience in the `SchedulesView.vue` by improving the behavior of the settings panel. Now, when the settings panel is toggled open, the view will automatically scroll to bring the panel into view smoothly.

User experience improvements:

* Added a `ref` named `settingsCol` to the settings panel column in the template to enable programmatic access.
* Updated the `toggleSettingsPanel` method to scroll the settings panel into view with smooth behavior when it is opened, using `$nextTick` and the new `settingsCol` reference.