### PR TITLE
Close #114: Disable tooltips on touch devices to prevent persistence

### DIFF
--- a/src/components/FilterSaveButton.vue
+++ b/src/components/FilterSaveButton.vue
@@ -23,12 +23,14 @@
 </template>
 
 <script>
+import { isTouchDevice } from '@/utils/common';
+
 export default {
   props: ["clickFuncSuper"],
   data() {
     return {
       loading: false,
-      isTouchDevice: window.matchMedia('(pointer: coarse)').matches,
+      isTouchDevice,
     }
   },
   methods: {

--- a/src/components/FilterSaveButton.vue
+++ b/src/components/FilterSaveButton.vue
@@ -2,6 +2,7 @@
   <v-tooltip
     text="현재 필터 정보를 이 기기의 기본값으로 저장합니다."
     location="top"
+    :disabled="isTouchDevice"
   >
     <template v-slot:activator="{ props }">
       <v-btn
@@ -27,6 +28,7 @@ export default {
   data() {
     return {
       loading: false,
+      isTouchDevice: window.matchMedia('(pointer: coarse)').matches,
     }
   },
   methods: {

--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -13,3 +13,5 @@ export function maxBytesRuleFactory(maxBytes, label = "해당 값") {
 }
 
 export const formatDateTime = dateTime => dateTime.toISO().substring(0, 19);
+
+export const isTouchDevice = window.matchMedia('(pointer: coarse)').matches;

--- a/src/views/SchedulesView.vue
+++ b/src/views/SchedulesView.vue
@@ -122,7 +122,7 @@ import {
   LS_KEY_CALENDAR_VIEW_MODE
 } from '@/utils/consts';
 import ScheduleDialog from '@/components/ScheduleDialog.vue';
-import { formatDateTime } from '@/utils/common';
+import { formatDateTime, isTouchDevice } from '@/utils/common';
 import { useDisplay } from 'vuetify';
 import ScheduleSettingsPanel from '@/components/ScheduleSettingsPanel.vue';
 
@@ -158,7 +158,7 @@ export default {
         mdAndDown,
         xlAndUp,
         showSettings: false,
-        isTouchDevice: window.matchMedia('(pointer: coarse)').matches,
+        isTouchDevice,
       };
     },
     created() {

--- a/src/views/SchedulesView.vue
+++ b/src/views/SchedulesView.vue
@@ -84,7 +84,7 @@
     class="schedules-view-fab"
     :class="loginInfo.isLoggedIn ? 'schedules-view-fab--stacked-above' : 'schedules-view-fab--lower'"
   >
-    <v-tooltip text="캘린더 설정" location="start">
+    <v-tooltip text="캘린더 설정" location="start" :disabled="isTouchDevice">
       <template v-slot:activator="{ props }">
         <v-btn
           v-bind="props"
@@ -158,6 +158,7 @@ export default {
         mdAndDown,
         xlAndUp,
         showSettings: false,
+        isTouchDevice: window.matchMedia('(pointer: coarse)').matches,
       };
     },
     created() {


### PR DESCRIPTION
This pull request improves the user experience on touch devices by disabling tooltips where they may interfere with usability. The changes ensure that tooltips are only shown on non-touch devices for relevant UI elements.

Enhancements for touch device compatibility:

* Added an `isTouchDevice` property to both `FilterSaveButton.vue` and `SchedulesView.vue` components to detect coarse pointer devices using `window.matchMedia('(pointer: coarse)').matches`. [[1]](diffhunk://#diff-72de8899cee51fa26ce17ebdbe1f0ed6d6d86518d672007f7215d8a6a610770cR31) [[2]](diffhunk://#diff-36c032cff02681b35386ea8ec8929b37f2b9a3ec1f967e49a076564ba08943fdR161)
* Updated the `v-tooltip` components in `FilterSaveButton.vue` and `SchedulesView.vue` to use the `:disabled="isTouchDevice"` binding, preventing tooltips from displaying on touch devices. [[1]](diffhunk://#diff-72de8899cee51fa26ce17ebdbe1f0ed6d6d86518d672007f7215d8a6a610770cR5) [[2]](diffhunk://#diff-36c032cff02681b35386ea8ec8929b37f2b9a3ec1f967e49a076564ba08943fdL87-R87)