### PR TITLE
Close #117: Sort stellars by generation with staff and graduated members placed last

### DIFF
--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -15,3 +15,12 @@ export function maxBytesRuleFactory(maxBytes, label = "해당 값") {
 export const formatDateTime = dateTime => dateTime.toISO().substring(0, 19);
 
 export const isTouchDevice = window.matchMedia('(pointer: coarse)').matches;
+
+// Returns a sort group number for a stellar (lower = earlier in list)
+// Active by generation (gen > 0) → active staff (gen 0) → graduated by generation → graduated staff
+export function getStellarGroupRank(stellar) {
+  if (!stellar.isGraduated && stellar.generation > 0) return 0;
+  if (!stellar.isGraduated && stellar.generation === 0) return 1;
+  if (stellar.isGraduated && stellar.generation > 0)  return 2;
+  return 3; // isGraduated && generation === 0
+}

--- a/src/views/SchedulesView.vue
+++ b/src/views/SchedulesView.vue
@@ -122,7 +122,7 @@ import {
   LS_KEY_CALENDAR_VIEW_MODE
 } from '@/utils/consts';
 import ScheduleDialog from '@/components/ScheduleDialog.vue';
-import { formatDateTime, isTouchDevice } from '@/utils/common';
+import { formatDateTime, isTouchDevice, getStellarGroupRank } from '@/utils/common';
 import { useDisplay } from 'vuetify';
 import ScheduleSettingsPanel from '@/components/ScheduleSettingsPanel.vue';
 
@@ -164,9 +164,7 @@ export default {
     created() {
       this.fetchStellarsAndInitFilter();
     },
-    mounted() {
-      this.loadSchedules();
-    },
+    mounted() {},
     components: { Calendar, ScheduleItem, ScheduleDialog, ScheduleSettingsPanel },
     methods: {
       async fetchStellarsAndInitFilter() {
@@ -176,6 +174,7 @@ export default {
           this.stellars = sortedData;
 
           this.initFilter();
+          this.loadSchedules();
         }
         catch (error) {
           this.noticeError(`스텔라 목록 조회 중 오류가 발생했습니다. ${error.response?.data?.message}`);
@@ -183,7 +182,12 @@ export default {
         }
       },
       sortStellars(data) {
-        return [...data].sort((a, b) => a.generation - b.generation || a.debutOrder - b.debutOrder);
+        return [...data].sort((a, b) => {
+          const groupDiff = getStellarGroupRank(a) - getStellarGroupRank(b);
+          if (groupDiff !== 0) return groupDiff;
+          if (a.generation !== b.generation) return a.generation - b.generation;
+          return a.debutOrder - b.debutOrder;
+        });
       },
       initFilter() {
         // load filter info from local storage and set the filter to it
@@ -261,6 +265,7 @@ export default {
         const vm = this;
         this.$axios.get(SCHEDULES_API_URL, { params })
           .then(response => {
+            const stellarRankMap = new Map(vm.stellars.map((s, idx) => [s.id, idx]));
             vm.schedules = response.data.content.map(elem => {
               elem.jsDate = DateTime.fromISO(elem.startDateTime).toJSDate();
               return elem;
@@ -271,8 +276,10 @@ export default {
               // sort by date time
               if (a.jsDate.getTime() !== b.jsDate.getTime()) return a.jsDate.getTime() - b.jsDate.getTime();
 
-              // sort by stellar id
-              return a.stellarId - b.stellarId;
+              // sort by stellar group rank
+              const rankA = stellarRankMap.has(a.stellarId) ? stellarRankMap.get(a.stellarId) : Infinity;
+              const rankB = stellarRankMap.has(b.stellarId) ? stellarRankMap.get(b.stellarId) : Infinity;
+              return rankA - rankB;
             });
           })
           .catch(error => {

--- a/src/views/SchedulesView.vue
+++ b/src/views/SchedulesView.vue
@@ -164,7 +164,6 @@ export default {
     created() {
       this.fetchStellarsAndInitFilter();
     },
-    mounted() {},
     components: { Calendar, ScheduleItem, ScheduleDialog, ScheduleSettingsPanel },
     methods: {
       async fetchStellarsAndInitFilter() {
@@ -279,7 +278,7 @@ export default {
               // sort by stellar group rank
               const rankA = stellarRankMap.has(a.stellarId) ? stellarRankMap.get(a.stellarId) : Infinity;
               const rankB = stellarRankMap.has(b.stellarId) ? stellarRankMap.get(b.stellarId) : Infinity;
-              return rankA - rankB;
+              return rankA - rankB || 0;
             });
           })
           .catch(error => {


### PR DESCRIPTION
This pull request improves the sorting logic for stellars and schedules in the application, ensuring a more meaningful display order based on graduation status and generation. It introduces a new utility function to group and rank stellars, updates the sorting logic in the schedules view, and makes the schedule loading process more robust.

**Stellar sorting and ranking improvements:**

* Added `getStellarGroupRank` to `common.js` to assign a sort group to each stellar based on graduation status and generation, ensuring active members and staff are prioritized appropriately.
* Updated the `sortStellars` method in `SchedulesView.vue` to use `getStellarGroupRank`, then generation, then debut order for sorting, providing a more logical and user-friendly order.
* Updated import statements to include the new `getStellarGroupRank` utility.

**Schedule sorting improvements:**

* Changed the schedule sorting logic to use the new stellar group ranking, ensuring schedules are grouped and ordered by the improved stellar order after sorting by date. [[1]](diffhunk://#diff-36c032cff02681b35386ea8ec8929b37f2b9a3ec1f967e49a076564ba08943fdR268) [[2]](diffhunk://#diff-36c032cff02681b35386ea8ec8929b37f2b9a3ec1f967e49a076564ba08943fdL274-R282)

**Schedule loading flow:**

* Moved the `loadSchedules` call to after the stellars have been fetched and sorted, ensuring schedules are loaded only after the necessary stellar data is available. [[1]](diffhunk://#diff-36c032cff02681b35386ea8ec8929b37f2b9a3ec1f967e49a076564ba08943fdL167-R167) [[2]](diffhunk://#diff-36c032cff02681b35386ea8ec8929b37f2b9a3ec1f967e49a076564ba08943fdR177-R190)